### PR TITLE
Match README.md title to repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hashicorp-ci
+# hashicorp-pipeline
 
 container with packer & terraform for hashicorp based CI/CD pipeline usage
 


### PR DESCRIPTION
So that the README.md title is less confusing, and shows the reader which repo they are looking at.